### PR TITLE
Add support for Go generics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.18.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Gocache
 
-Gocache is an in-memory cache implementation written in Go.
+Gocache is a **generic** in-memory cache implementation written in Go.
+
+It requires Go v1.18+ due to the generics support.
 
 ## Table of Contents
 1. [TODOs](#todos)
@@ -20,18 +22,13 @@ Gocache is an in-memory cache implementation written in Go.
 - [ ] Memory profiling + improvements.
 - [ ] Badges (+ code report + unit tests).
 - [ ] Concurrent safety.
-- [ ] Scan parser method.
-
-### Architectural decisions
-
-Due to the non-existence of generics in Go, the `interface{}` was used instead, what forces us to use type casting
-(so reflection) on data fetches.
+- [ ] GoDocs.
 
 ### Data structures & algorithms
 
 #### Non-limited cache (HashMap)
 
-Non-limited cache that uses a HashMap (`map[string]interface{}`) under the hood.
+Non-limited cache that uses a HashMap (`map[string]any`) under the hood.
 
 Time cost analysis:
 
@@ -41,7 +38,7 @@ Time cost analysis:
 #### LRU cache (HashMap + LinkedList)
 
 Limited (with [LRU replacement](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) cache
-that uses a HashMap(`map[string]interface{}`) and a doubly-linked list under the hood.
+that uses a HashMap(`map[string]any`) and a doubly-linked list under the hood.
 
 Time cost analysis:
 
@@ -64,7 +61,7 @@ func main() {
 	key1, key2 := "key1", "key2"
 	val1, val2 := 1, 2
 
-	cache := gocache.New()
+	cache := gocache.New[int]()
 	cache.Set(key1, val1)
 	cache.Set(key2, val2)
 
@@ -87,7 +84,7 @@ func main() {
 	val1, val2 := 1, 2
     size := 1
 
-	cache := gocache.NewR(size)
+	cache := gocache.NewR[int](size)
 	cache.Set(key1, val1)
 	cache.Set(key2, val2)
 

--- a/cache.go
+++ b/cache.go
@@ -1,24 +1,26 @@
 package gocache
 
-type Cache struct {
-	items map[string]interface{}
+type Cache[V any] struct {
+	items map[string]V
 }
 
-func New() *Cache {
-	return &Cache{
-		items: make(map[string]interface{}),
+func New[V any]() *Cache[V] {
+	return &Cache[V]{
+		items: make(map[string]V),
 	}
 }
 
-func (c *Cache) Get(key string) interface{} {
+func (c *Cache[V]) Get(key string) V {
+	var noop V
+
 	item, ok := c.items[key]
 	if !ok {
-		return nil
+		return noop
 	}
 
 	return item
 }
 
-func (c *Cache) Set(key string, value interface{}) {
+func (c *Cache[V]) Set(key string, value V) {
 	c.items[key] = value
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -12,16 +12,16 @@ func TestCache(t *testing.T) {
 	key1, key2 := "key1", "key2"
 	val1, val2 := 1, 2
 
-	cache := New()
+	cache := New[int]()
 	cache.Set(key1, val1)
 	cache.Set(key2, val2)
 
-	got := cache.Get(key1).(int)
+	got := cache.Get(key1)
 	if val1 != got {
 		t.Fatalf("Get returned unexpected value - expected: %v, got: %v", val1, got)
 	}
 
-	got = cache.Get(key2).(int)
+	got = cache.Get(key2)
 	if val2 != got {
 		t.Fatalf("Get returned unexpected value - expected: %v, got: %v", val2, got)
 	}
@@ -36,7 +36,7 @@ func BenchmarkCache100000(b *testing.B)  { benchmarkCache(100000, b) }
 func BenchmarkCache1000000(b *testing.B) { benchmarkCache(1000000, b) }
 
 func benchmarkCache(items int, b *testing.B) {
-	cache := New()
+	cache := New[int]()
 	var m1, m2 runtime.MemStats
 
 	runtime.ReadMemStats(&m1)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module pkg.friendsofgo.tech/gocache
 
-go 1.13
+go 1.18

--- a/list.go
+++ b/list.go
@@ -1,11 +1,11 @@
 package gocache
 
-type list struct {
-	head *listItem
-	tail *listItem
+type list[V any] struct {
+	head *listItem[V]
+	tail *listItem[V]
 }
 
-func (l *list) prepend(item *listItem) {
+func (l *list[V]) prepend(item *listItem[V]) {
 	if l.head == nil {
 		l.head = item
 		l.tail = item
@@ -16,7 +16,7 @@ func (l *list) prepend(item *listItem) {
 	l.head = item
 }
 
-func (l *list) update(item *listItem) {
+func (l *list[V]) update(item *listItem[V]) {
 	if l.head == item {
 		return
 	}
@@ -37,7 +37,7 @@ func (l *list) update(item *listItem) {
 	l.head.prev = nil
 }
 
-func (l *list) pop() (item *listItem) {
+func (l *list[V]) pop() (item *listItem[V]) {
 	if l.head == nil {
 		return
 	}
@@ -53,14 +53,14 @@ func (l *list) pop() (item *listItem) {
 	return
 }
 
-type listItem struct {
-	next *listItem
-	prev *listItem
+type listItem[V any] struct {
+	next *listItem[V]
+	prev *listItem[V]
 	key  string
-	val  interface{}
+	val  V
 }
 
-func (item *listItem) prepend(item2 *listItem) {
+func (item *listItem[V]) prepend(item2 *listItem[V]) {
 	item.prev = item2
 	item2.next = item
 }

--- a/list_test.go
+++ b/list_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestList(t *testing.T) {
 	t.Run("given an empty list then head and tail are nil", func(t *testing.T) {
-		l := new(list)
+		l := new(list[int])
 
 		if nil != l.head {
 			t.Fatalf("unexpected list.head - expected: %v, got: %v", nil, l.head)
@@ -16,9 +16,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a single item list then and tail are the same item", func(t *testing.T) {
-		item1 := &listItem{key: "one"}
+		item1 := &listItem[int]{key: "one"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 
 		if item1 != l.head {
@@ -31,9 +31,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a list with two items then one corresponds to the head and the other one to the tail", func(t *testing.T) {
-		item1, item2 := &listItem{key: "one"}, &listItem{key: "two"}
+		item1, item2 := &listItem[int]{key: "one"}, &listItem[int]{key: "two"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 		l.prepend(item2)
 
@@ -47,9 +47,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a list with three items then first one corresponds to the head and the last one to the tail", func(t *testing.T) {
-		item1, item2, item3 := &listItem{key: "one"}, &listItem{key: "two"}, &listItem{key: "three"}
+		item1, item2, item3 := &listItem[int]{key: "one"}, &listItem[int]{key: "two"}, &listItem[int]{key: "three"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 		l.prepend(item2)
 		l.prepend(item3)
@@ -64,9 +64,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a single item list then the update does nothing", func(t *testing.T) {
-		item1 := &listItem{key: "one"}
+		item1 := &listItem[int]{key: "one"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 
 		l.update(item1)
@@ -89,9 +89,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a list with two items then the update sets the second one as the head", func(t *testing.T) {
-		item1, item2 := &listItem{key: "one"}, &listItem{key: "two"}
+		item1, item2 := &listItem[int]{key: "one"}, &listItem[int]{key: "two"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 		l.prepend(item2)
 
@@ -123,9 +123,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a list with three items then the update sets the second one as the head", func(t *testing.T) {
-		item1, item2, item3 := &listItem{key: "one"}, &listItem{key: "two"}, &listItem{key: "three"}
+		item1, item2, item3 := &listItem[int]{key: "one"}, &listItem[int]{key: "two"}, &listItem[int]{key: "three"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 		l.prepend(item2)
 		l.prepend(item3)
@@ -166,7 +166,7 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given an empty list then pop returns nil", func(t *testing.T) {
-		l := new(list)
+		l := new(list[int])
 
 		got := l.pop()
 		if nil != got {
@@ -183,9 +183,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a single item list then pop returns the item and the list is empty", func(t *testing.T) {
-		item1 := &listItem{key: "one"}
+		item1 := &listItem[int]{key: "one"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 
 		got := l.pop()
@@ -203,9 +203,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a list with two items then pop returns the last item and the list is a single one", func(t *testing.T) {
-		item1, item2 := &listItem{key: "one"}, &listItem{key: "two"}
+		item1, item2 := &listItem[int]{key: "one"}, &listItem[int]{key: "two"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 		l.prepend(item2)
 
@@ -224,9 +224,9 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("given a list with three items then pop returns the last item and the list size is two", func(t *testing.T) {
-		item1, item2, item3 := &listItem{key: "one"}, &listItem{key: "two"}, &listItem{key: "three"}
+		item1, item2, item3 := &listItem[int]{key: "one"}, &listItem[int]{key: "two"}, &listItem[int]{key: "three"}
 
-		l := new(list)
+		l := new(list[int])
 		l.prepend(item1)
 		l.prepend(item2)
 		l.prepend(item3)

--- a/with_replacement.go
+++ b/with_replacement.go
@@ -1,40 +1,43 @@
 package gocache
 
-type CacheR struct {
-	items map[string]*listItem
+type CacheR[V any] struct {
+	items map[string]*listItem[V]
 	cap   int
-	lru   *list
+	lru   *list[V]
 }
 
-func NewR(cap int) *CacheR {
-	return &CacheR{
-		items: make(map[string]*listItem),
+func NewR[V any](cap int) *CacheR[V] {
+	return &CacheR[V]{
+		items: make(map[string]*listItem[V]),
 		cap:   cap,
-		lru:   new(list),
+		lru:   new(list[V]),
 	}
 }
 
-func (c *CacheR) Get(key string) interface{} {
+func (c *CacheR[V]) Get(key string) V {
+	var noop V
+
 	item, ok := c.items[key]
 	if !ok {
-		return nil
+		return noop
 	}
 
 	c.lru.update(item)
+
 	return item.val
 }
 
-func (c *CacheR) Set(key string, val interface{}) {
+func (c *CacheR[V]) Set(key string, val V) {
 	if len(c.items) == c.cap {
 		c.evict()
 	}
 
-	newItem := &listItem{key: key, val: val}
+	newItem := &listItem[V]{key: key, val: val}
 	c.lru.prepend(newItem)
 	c.items[key] = newItem
 }
 
-func (c *CacheR) evict() {
+func (c *CacheR[V]) evict() {
 	evicted := c.lru.pop()
 
 	if evicted != nil {

--- a/with_replacement_test.go
+++ b/with_replacement_test.go
@@ -12,28 +12,28 @@ func TestCacheR(t *testing.T) {
 	key1, key2, key3, key4 := "key1", "key2", "key3", "key4"
 	val1, val2, val3, val4 := 1, 2, 3, 4
 
-	cache := NewR(2)
+	cache := NewR[int](2)
 	cache.Set(key1, val1)
 	cache.Set(key2, val2)
 	cache.Set(key3, val3)
 	cache.Set(key4, val4)
 
 	got := cache.Get(key1)
-	if nil != got {
+	if 0 != got {
 		t.Fatalf("unexpected cache.Get - expected: %v, got: %v", nil, got)
 	}
 
 	got = cache.Get(key2)
-	if nil != got {
+	if 0 != got {
 		t.Fatalf("unexpected cache.Get - expected: %v, got: %v", nil, got)
 	}
 
-	got = cache.Get(key3).(int)
+	got = cache.Get(key3)
 	if val3 != got {
 		t.Fatalf("unexpected cache.Get - expected: %v, got: %v", val3, got)
 	}
 
-	got = cache.Get(key4).(int)
+	got = cache.Get(key4)
 	if val4 != got {
 		t.Fatalf("unexpected cache.Get - expected: %v, got: %v", val4, got)
 	}
@@ -64,7 +64,7 @@ func BenchmarkCacheR100000x100000(b *testing.B)  { benchmarkCacheR(100000, 10000
 func BenchmarkCacheR1000000x100000(b *testing.B) { benchmarkCacheR(1000000, 100000, b) }
 
 func benchmarkCacheR(items, size int, b *testing.B) {
-	cache := NewR(size)
+	cache := NewR[int](size)
 	var m1, m2 runtime.MemStats
 
 	runtime.ReadMemStats(&m1)
@@ -78,11 +78,11 @@ func benchmarkCacheR(items, size int, b *testing.B) {
 	val := rand.Intn(items)
 	key := fmt.Sprintf("key%d", val)
 
-	var expected interface{}
+	var expected int
 	if val >= items-size {
 		expected = val
 	} else {
-		expected = nil
+		expected = 0
 	}
 	b.ResetTimer()
 


### PR DESCRIPTION
## Description

It replaces (**backwards incompatible**) reflection based on empty interface (`interface{}`) by generics (`[V any]`). 

Keys are still represented as `string` to avoid _too much_ generics overhead (note `New[int]()` vs `New[string, int]()`, for instance). But we could extend the support for an even more generic implementation.